### PR TITLE
fix: download pulumi version based on pulumi sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "pulumi (>=3.156.0,<4.0.0)",
-    "pulumi-aws (>=6.72.0,<7.0.0)",
+    "pulumi (==3.187.0)",
+    "pulumi-aws (==7.2.0)",
     "click",
     "appdirs",
     "requests",
     "rich>=14.0.0",
     "boto3",
-    "pulumi-cloudflare>=6.4.1",
+    "pulumi-cloudflare==6.4.1",
 ]
 
 

--- a/stelvio/pulumi.py
+++ b/stelvio/pulumi.py
@@ -9,6 +9,7 @@ import sys
 import tarfile
 import zipfile
 from importlib import import_module
+from importlib.metadata import version
 from io import BytesIO
 from pathlib import Path
 from typing import Literal, Optional
@@ -46,7 +47,8 @@ from stelvio.rich_deployment_handler import RichDeploymentHandler
 logger = logging.getLogger(__name__)
 console = Console(soft_wrap=True)
 
-PULUMI_VERSION = "v3.170.0"
+
+PULUMI_VERSION = "v" + version("pulumi")
 
 
 def _should_skip_diagnostic(message: str) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -515,7 +515,7 @@ wheels = [
 
 [[package]]
 name = "pulumi"
-version = "3.170.0"
+version = "3.187.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "debugpy" },
@@ -527,21 +527,21 @@ dependencies = [
     { name = "semver" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/f0/b23f19dae871bb3d43bf3f29b11535d536d2ef9a4b7703e4d2467afc6cf9/pulumi-3.170.0-py3-none-any.whl", hash = "sha256:824b3c293c659be0cd6b975a719d921987a359f4c97639fc7ecd24a83e8cfd4d", size = 338393, upload-time = "2025-05-15T15:00:49.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f1/7e45735fde30f7b587dad9f8824669afc228bb6d1ebc13bfec3f7ecd3d7f/pulumi-3.187.0-py3-none-any.whl", hash = "sha256:2aaa75651884e34fef3340aa8510db85e966520c079f81e39ab8ed59c016ce92", size = 364301, upload-time = "2025-07-31T15:07:21.833Z" },
 ]
 
 [[package]]
 name = "pulumi-aws"
-version = "6.80.0"
+version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parver" },
     { name = "pulumi" },
     { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/eb/577a8f8874a2ec04f086c7268279b91fd5e5b2269a447d99567a9d7e1df8/pulumi_aws-6.80.0.tar.gz", hash = "sha256:ad675dc993fb085e8a678a330de34d85eec05047d9e8ea370f5ffa86567e1f12", size = 7683131, upload-time = "2025-05-07T01:21:57.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/99/049dba0cacabc3a75a8e183241ad1d050832ffec464649eac48378f94875/pulumi_aws-7.2.0.tar.gz", hash = "sha256:9d2e6e9e420d5563f2a3dc975d546968b3d745f1e76a744ea6c08e106fbaf62c", size = 8009236, upload-time = "2025-07-31T23:30:17.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/62/17f5a6328902c8d67ce26174e2a2ff29202bf9f4d41b50ae226899a2f704/pulumi_aws-6.80.0-py3-none-any.whl", hash = "sha256:ad0ad571de527d444a9eb7cf0afd9b21d81841d0d7b9c66ee3f91b3d3b4d8732", size = 10428841, upload-time = "2025-05-07T01:21:53.547Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/71/d193f2dc37361dc8baef20101786774b1d7467209a08627537630b230d0a/pulumi_aws-7.2.0-py3-none-any.whl", hash = "sha256:f63838776c8afdd70568569704b6f9397c74a6cf7e44f713aa9a55182bc0213c", size = 10886044, upload-time = "2025-07-31T23:30:13.617Z" },
 ]
 
 [[package]]
@@ -769,9 +769,9 @@ requires-dist = [
     { name = "appdirs" },
     { name = "boto3" },
     { name = "click" },
-    { name = "pulumi", specifier = ">=3.156.0,<4.0.0" },
-    { name = "pulumi-aws", specifier = ">=6.72.0,<7.0.0" },
-    { name = "pulumi-cloudflare", specifier = ">=6.4.1" },
+    { name = "pulumi", specifier = "==3.187.0" },
+    { name = "pulumi-aws", specifier = "==7.2.0" },
+    { name = "pulumi-cloudflare", specifier = "==6.4.1" },
     { name = "requests" },
     { name = "rich", specifier = ">=14.0.0" },
 ]


### PR DESCRIPTION
In this PR I make sure that Pulumi CLI that Stelvio downloads is compatible with Pulumi Python SDK. Also I pinned pulumi, pulumi-aws and pulumi-cloudflare packages to exact version in pyproject.toml